### PR TITLE
Improve specs (slightly)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'sprockets', '~> 4.0'
 group :development, :test do
   gem "jquery-rails" # jquery-rails is used by the dummy application
   gem "factory_bot_rails"
+  gem "rubocop"
   gem "byebug" unless ENV["CI"]
 end
 gem "mutex_m"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
       activesupport (>= 6.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.20)
     benchmark (0.4.1)
@@ -199,6 +200,9 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (8.0.0)
       railties (>= 3.2.16)
+    json (2.13.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -232,6 +236,10 @@ GEM
     paper_trail (15.1.0)
       activerecord (>= 6.1)
       request_store (~> 1.4)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
     pp (0.6.2)
       prettyprint
     premailer (1.27.0)
@@ -239,6 +247,7 @@ GEM
       css_parser (>= 1.19.0)
       htmlentities (>= 4.0.0)
     prettyprint (0.2.0)
+    prism (1.4.0)
     psych (5.2.6)
       date
       stringio
@@ -292,6 +301,7 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
+    rainbow (3.1.1)
     rake (13.3.0)
     ransack (3.2.1)
       activerecord (>= 6.1.5)
@@ -308,6 +318,7 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
+    regexp_parser (2.10.0)
     reline (0.6.2)
       io-console (~> 0.5)
     request_store (1.7.0)
@@ -334,6 +345,21 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.4)
+    rubocop (1.79.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -361,6 +387,9 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unaccent (0.4.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
     warden (1.2.9)
       rack (>= 2.0.9)
     websocket-driver (0.8.0)
@@ -386,6 +415,7 @@ DEPENDENCIES
   observer
   ransack_ui
   rspec-rails
+  rubocop
   sprockets (~> 4.0)
   sqlite3
 

--- a/spec/controllers/endpoints_controller_spec.rb
+++ b/spec/controllers/endpoints_controller_spec.rb
@@ -24,14 +24,18 @@ RSpec.describe FfcrmEndpoint::EndpointsController, type: :controller do
   end
 
   describe 'consume' do
-    it 'should call process when authenticate returns true' do
-      post :consume, params: { klass_name: :authenticating_endpoint, format: :js }
-      expect(response.status).to eql(201)
+    context "authenticated" do
+      it 'call processes the request' do
+        get :consume, params: { klass_name: :authenticating_endpoint, format: :js }
+        expect(response.status).to eql(201)
+      end
     end
 
-    it 'should not call process when authenticate returns false' do
-      post :consume, params: { klass_name: :non_authenticating_endpoint, format: :js }
-      expect(response.status).to eql(401)
+    context "unauthenticated" do
+      it 'rejects the request' do
+        get :consume, params: { klass_name: :non_authenticating_endpoint, format: :js }
+        expect(response.status).to eql(401)
+      end
     end
   end
 end

--- a/spec/controllers/endpoints_controller_spec.rb
+++ b/spec/controllers/endpoints_controller_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe FfcrmEndpoint::EndpointsController, type: :controller do
-
   let(:endpoint) { double(FfcrmEndpoint::Endpoint) }
 
-  describe "consume" do
-
-    it "should call process when authenticate returns true" do
+  describe 'consume' do
+    it 'should call process when authenticate returns true' do
       expect(endpoint).to receive(:process)
       expect(endpoint).to receive(:authenticate).and_return(true)
       allow(controller).to receive(:endpoint).and_return(endpoint)
@@ -14,14 +12,12 @@ RSpec.describe FfcrmEndpoint::EndpointsController, type: :controller do
       expect(response.status).to eql(201)
     end
 
-    it "should not call process when authenticate returns false" do
+    it 'should not call process when authenticate returns false' do
       expect(endpoint).not_to receive(:process)
       expect(endpoint).to receive(:authenticate).and_return(false)
       expect(controller).to receive(:endpoint).and_return(endpoint)
       get :consume, params: { klass_name: :my_custom_endpoint, format: :js }
       expect(response.status).to eql(401)
     end
-
   end
-
 end

--- a/spec/controllers/endpoints_controller_spec.rb
+++ b/spec/controllers/endpoints_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe FfcrmEndpoint::EndpointsController, type: :controller do
     end
 
     def process
-      raise "Should not be called"
+      raise 'Should not be called'
     end
   end
 

--- a/spec/controllers/endpoints_controller_spec.rb
+++ b/spec/controllers/endpoints_controller_spec.rb
@@ -3,20 +3,34 @@ require 'rails_helper'
 RSpec.describe FfcrmEndpoint::EndpointsController, type: :controller do
   let(:endpoint) { double(FfcrmEndpoint::Endpoint) }
 
+  class AuthenticatingEndpoint < FfcrmEndpoint::Endpoint
+    def authenticate
+      true
+    end
+
+    def process
+      # Simulate processing logic
+    end
+  end
+
+  class NonAuthenticatingEndpoint < FfcrmEndpoint::Endpoint
+    def authenticate
+      false
+    end
+
+    def process
+      raise "Should not be called"
+    end
+  end
+
   describe 'consume' do
     it 'should call process when authenticate returns true' do
-      expect(endpoint).to receive(:process)
-      expect(endpoint).to receive(:authenticate).and_return(true)
-      allow(controller).to receive(:endpoint).and_return(endpoint)
-      get :consume, params: { klass_name: :my_custom_endpoint, format: :js }
+      post :consume, params: { klass_name: :authenticating_endpoint, format: :js }
       expect(response.status).to eql(201)
     end
 
     it 'should not call process when authenticate returns false' do
-      expect(endpoint).not_to receive(:process)
-      expect(endpoint).to receive(:authenticate).and_return(false)
-      expect(controller).to receive(:endpoint).and_return(endpoint)
-      get :consume, params: { klass_name: :my_custom_endpoint, format: :js }
+      post :consume, params: { klass_name: :non_authenticating_endpoint, format: :js }
       expect(response.status).to eql(401)
     end
   end

--- a/spec/controllers/endpoints_controller_spec.rb
+++ b/spec/controllers/endpoints_controller_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe FfcrmEndpoint::EndpointsController, type: :controller do
   end
 
   describe 'consume' do
-    context "authenticated" do
+    context 'authenticated' do
       it 'call processes the request' do
         get :consume, params: { klass_name: :authenticating_endpoint, format: :js }
         expect(response.status).to eql(201)
       end
     end
 
-    context "unauthenticated" do
+    context 'unauthenticated' do
       it 'rejects the request' do
         get :consume, params: { klass_name: :non_authenticating_endpoint, format: :js }
         expect(response.status).to eql(401)

--- a/spec/lib/endpoint_spec.rb
+++ b/spec/lib/endpoint_spec.rb
@@ -1,10 +1,16 @@
 require 'rails_helper'
+require 'action_dispatch/testing/test_request'
 
 describe FfcrmEndpoint::Endpoint do
   describe 'initialize' do
     it 'should initialize params'
-    it 'should raise an error if action is blank' do
-      # expect { something }.to raise_error(SomeError)
+
+    context 'with an incomplete request' do
+      it 'should raise an error if action is blank' do
+        expect do
+          FfcrmEndpoint::Endpoint.new(ActionDispatch::TestRequest.create)
+        end.to raise_error(FfcrmEndpoint::EndpointNoActionError)
+      end
     end
   end
 
@@ -13,7 +19,24 @@ describe FfcrmEndpoint::Endpoint do
 
     it 'should call process on the subclass'
 
-    it 'should raise an error if it cannot find the subclass'
+    context 'with an unrecognised handler' do
+      let(:test_request) do
+        test_request = ActionDispatch::TestRequest.create
+        test_request.request_method = 'POST'
+        test_request.path = '/example'
+        test_request.set_header('HTTP_AUTHORIZATION', 'Bearer testtoken123')
+        test_request.request_parameters = { klass_name: 'DoesntExist' }
+        test_request
+      end
+
+      let(:endpoint) do
+        FfcrmEndpoint::Endpoint.new(test_request)
+      end
+
+      it 'raises an error if it cannot find the subclass' do
+        expect { endpoint.process }.to raise_error(FfcrmEndpoint::EndpointNotDefinedError)
+      end
+    end
   end
 
   describe 'config' do

--- a/spec/lib/endpoint_spec.rb
+++ b/spec/lib/endpoint_spec.rb
@@ -1,34 +1,26 @@
 require 'rails_helper'
 
 describe FfcrmEndpoint::Endpoint do
-
-  describe "initialize" do
-
-    it "should initialize params"
-    it "should raise an error if action is blank" do
+  describe 'initialize' do
+    it 'should initialize params'
+    it 'should raise an error if action is blank' do
       # expect { something }.to raise_error(SomeError)
     end
-
   end
 
-  describe "process" do
+  describe 'process' do
+    it 'should find the subclass'
 
-    it "should find the subclass"
+    it 'should call process on the subclass'
 
-    it "should call process on the subclass"
-
-    it "should raise an error if it cannot find the subclass"
-
+    it 'should raise an error if it cannot find the subclass'
   end
 
-  describe "config" do
-
-    it "should provide access to subclass settings"
-
+  describe 'config' do
+    it 'should provide access to subclass settings'
   end
 
-  it "should register a subclass"
-  it "should return the subclass class"
-  it "should return the subclass class name"
-
+  it 'should register a subclass'
+  it 'should return the subclass class'
+  it 'should return the subclass class name'
 end

--- a/spec/routing/endpoint_routing_spec.rb
+++ b/spec/routing/endpoint_routing_spec.rb
@@ -1,25 +1,28 @@
 require 'rails_helper'
 
 describe 'EndpointsController', type: :routing do
-
-  it "generates endpoint route for custom action [GET]" do
-    expect(get: "endpoints/custom").to route_to(controller: "ffcrm_endpoint/endpoints", action: "consume", klass_name: "custom")
+  it 'generates endpoint route for custom action [GET]' do
+    expect(get: 'endpoints/custom').to route_to(controller: 'ffcrm_endpoint/endpoints', action: 'consume',
+                                                klass_name: 'custom')
   end
 
-    it "generates endpoint route for custom action [GET]" do
-      expect(:get => "endpoints/custom").to route_to(controller: "ffcrm_endpoint/endpoints", action: "consume", klass_name: "custom")
-    end
-
-    it "generates endpoint route for custom action [POST]" do
-      expect(:post => "endpoints/custom").to route_to(controller: "ffcrm_endpoint/endpoints", action: "consume", klass_name: "custom")
-    end
-
-    it "generates endpoint route for custom action [PUT]" do
-      expect(:put => "endpoints/custom").to route_to(controller: "ffcrm_endpoint/endpoints", action: "consume", klass_name: "custom")
-    end
-
-  it "generates endpoint route for custom action [PUT]" do
-    expect(put: "endpoints/custom").to route_to(controller: "ffcrm_endpoint/endpoints", action: "consume", klass_name: "custom")
+  it 'generates endpoint route for custom action [GET]' do
+    expect(get: 'endpoints/custom').to route_to(controller: 'ffcrm_endpoint/endpoints', action: 'consume',
+                                                klass_name: 'custom')
   end
 
+  it 'generates endpoint route for custom action [POST]' do
+    expect(post: 'endpoints/custom').to route_to(controller: 'ffcrm_endpoint/endpoints', action: 'consume',
+                                                 klass_name: 'custom')
+  end
+
+  it 'generates endpoint route for custom action [PUT]' do
+    expect(put: 'endpoints/custom').to route_to(controller: 'ffcrm_endpoint/endpoints', action: 'consume',
+                                                klass_name: 'custom')
+  end
+
+  it 'generates endpoint route for custom action [PUT]' do
+    expect(put: 'endpoints/custom').to route_to(controller: 'ffcrm_endpoint/endpoints', action: 'consume',
+                                                klass_name: 'custom')
+  end
 end


### PR DESCRIPTION
- Rubocop
- Use clearer example classes, so that devs building on this see a bit of how handlers should be built
- Add coverage to lib/endpoint_spec with a faux request. I got about half way through before realising the route and controller tests do a pretty good job of covering this/its intrinsicly a controller test. But more coverage can't hurt.
